### PR TITLE
added luup.set_failure(false) in startup to avoid "Can't detect device";...

### DIFF
--- a/L_Arduino.lua
+++ b/L_Arduino.lua
@@ -569,6 +569,7 @@ end
 
 
 function startup(lul_device)
+	luup.set_failure(false)
 	ARDUINO_DEVICE = lul_device
 
 	setVariableIfChanged(ARDUINO_SID, "PluginVersion", PLUGIN_VERSION, ARDUINO_DEVICE)


### PR DESCRIPTION
... see Known Issues here: http://support.getvera.com/customer/portal/articles/1803253-ui7-%E2%96%BE-version-7-0-3-1-7-481-1-7-906-%E2%96%BE-dec-19-2014