### PR TITLE
Update device "status" when dimming

### DIFF
--- a/I_Arduino1.xml
+++ b/I_Arduino1.xml
@@ -37,10 +37,31 @@
   			if (p ~= nil) then p.switchPower(lul_device, lul_settings.newTargetValue)  end  			return 4,0  		</job>
     </action>
     <action>
+      <serviceId>urn:micasaverde-com:serviceId:HaDevice1</serviceId>
+      <name>ToggleState</name>
+      <run>
+        local status = luup.variable_get("urn:upnp-org:serviceId:SwitchPower1", "Status", lul_device)
+		if(status=="0") then
+			p.switchPower(lul_device, 1) 
+			return 4,0
+		else
+			p.switchPower(lul_device, 0) 
+			return 4,0
+		end
+      </run>
+    </action>
+    <action>
   		<serviceId>urn:upnp-org:serviceId:Dimming1</serviceId>
   		<name>SetLoadLevelTarget</name>
   		<job>
-  			if (p ~= nil) then p.setDimmerLevel(lul_device, lul_settings.newLoadlevelTarget) end			return 4,0		</job>
+  			if (p ~= nil) then 
+				p.setDimmerLevel(lul_device, lul_settings.newLoadlevelTarget) 
+				if(lul_settings.newLoadlevelTarget ~= "0")then
+					luup.variable_set("urn:upnp-org:serviceId:SwitchPower1","Status",1,lul_device)
+				else
+					luup.variable_set("urn:upnp-org:serviceId:SwitchPower1","Status",0,lul_device)
+				end
+			end			return 4,0		</job>
     </action>
     <action>
   		<serviceId>urn:micasaverde-com:serviceId:DoorLock1</serviceId>


### PR DESCRIPTION
This change will update the device "status" to 1 or 0 if the device is
dimmed between 1% and 99%.  Some apps use this to show if the device is
off or on (ImperiHome).  So if the device is dimmed to 50% the slide
will move and it will now look like it's on.